### PR TITLE
Fix race conditions in enable-link

### DIFF
--- a/src/overtone/ableton_link.clj
+++ b/src/overtone/ableton_link.clj
@@ -64,21 +64,21 @@
 (defn enable-link
   "Enable link if `bool` is `true`, disable it otherwise."
   [bool]
-  (locking link-running?  ; Protect against retries which could lead to extra event threads being spawned.
+  (locking link-running?  ;; Protect against retries which could lead to extra event threads being spawned.
     (swap! link-running? (fn [state]
                            (if (true? bool)
                              ;; The caller wants us to be running.
                              (if state
-                               state  ; Already running, no need to change anything.
-                               (let [run? (atom true)]  ; Start Link and the clock thread.
+                               state  ;; Already running, no need to change anything.
+                               (let [run? (atom true)]  ;; Start Link and the clock thread.
                                  (create-clock-thread run?)
                                  (-enable-link -AL-pointer true)
-                                 (fn [] (reset! run? false))))  ; State becomes function that will stop clock thread.
+                                 (fn [] (reset! run? false))))  ;; State becomes function that will stop clock thread.
                              ;; The caller wants us to be stopped.
-                             (when state  ; We only need to do anything if we were running.
-                               (state)  ; Call the function that stops the clock thread.
+                             (when state  ;; We only need to do anything if we were running.
+                               (state)  ;; Call the function that stops the clock thread.
                                (-enable-link -AL-pointer false)
-                               nil))))))  ; State becomes nil, indicating we are no longer running.
+                               nil))))))  ;; State becomes nil, indicating we are no longer running.
 
 (defn link-enabled?
   "Returns true if link is enabled"


### PR DESCRIPTION
There were a number of problems in the implementation which could lead to extra copies of the clock thread running.

* The clock thread was looking at a global atom to tell it if it should be running; if Link was disabled and then re-enabled within the second during which that thread was asleep, it would never notice that this atom had become false, so the old thread would continue to run, even after a new one had started up. I resolved this by having the thread use a local atom which is let-bound when Link is started, and only accessible to the thread itself, and a function that will be called to shut down that thread. So even if a new thread is started before the old thread notices it should be shut down, the old thread will still properly do so because it has its own atom to tell it.

* `enable-link` itself had race conditions because it was using `reset!` to change the value of `link-running?` after having dereferenced to check its old value, so if it was called from multiple threads, each one could see a `false` value initially and start up a new copy of the clock thread. The safe way to ensure something happens only once with an atom is to use `swap!` rather than `reset!`.

*  But even `swap!` is only safe with pure functions (no side effects). Since starting Link and the clock thread are absolutely side effects, we need to protect the body of `enable-link` with a lock to ensure that only one thread can be running it at a time.