### PR TITLE
Fix race condition in clock thread

### DIFF
--- a/src/overtone/ableton_link.clj
+++ b/src/overtone/ableton_link.clj
@@ -49,7 +49,7 @@
                     (<= (second (peek @event-queue-atom))
                         (-get-beat -AL-pointer)))
           (let [event (-> @event-queue-atom peek first)]
-            (reset! event-queue-atom (pop @event-queue-atom))
+            (swap! event-queue-atom pop)
             (when-not @(:stop-atom event)
               (swallow-exceptions ((:fun event)))
               (when (:recurring event)


### PR DESCRIPTION
It's not safe to combine `reset!` in this thread for popping items off
the queue with `swap!` in `append-event-to-queue` to add them, because
the `reset!` can end up losing something that was being swapped in at
the same time. Using `swap!` in both places is not only more concise,
but it is also safe and correct, since the functions being passed to
`swap!` are pure, so if they have to be retried because of threads
invoking them at the same time, the end result will be the correct
application of both desired changes.